### PR TITLE
xSNOB Boost Tooltip Link

### DIFF
--- a/components/UI/Buttons/ContainedButton/index.js
+++ b/components/UI/Buttons/ContainedButton/index.js
@@ -41,6 +41,7 @@ const ContainedButton = React.forwardRef(({
     <Button
       ref={ref}
       href={href}
+      target="_blank"
       component={href ? ButtonLink : 'button'}
       className={clsx(className, classes.root)}
       classes={{

--- a/parts/Compound/CompoundListItem/Info/index.js
+++ b/parts/Compound/CompoundListItem/Info/index.js
@@ -66,6 +66,7 @@ const Info = ({ icon, buttonText, boost }) => {
           size="small"
           disableElevation
           endIcon={<HelpOutlineIcon />}
+          href="https://snowballs.gitbook.io/snowball-docs/governance/xsnob/reward-boosting"
         >
           {buttonText}
         </ContainedButton>


### PR DESCRIPTION
https://app.asana.com/0/1200430190389164/1200994952555083

The "More Info" button should link to https://snowballs.gitbook.io/snowball-docs/governance/xsnob/reward-boosting

The link should open in a new tab.

It currently does not link anywhere.