### PR TITLE
update staking page when switch wallets

### DIFF
--- a/contexts/staking-context.js
+++ b/contexts/staking-context.js
@@ -66,22 +66,16 @@ export function StakingContractProvider({ children }) {
     if (isEmpty(account)) {
       setGauges([])
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gaugeProxyContract, account, pools]);
 
-  useEffect(() => {
     if (!isEmpty(snowballContract)) {
       getSnowballInfo()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [snowballContract])
 
-  useEffect(() => {
     if (!isEmpty(snowconeContract)) {
       getSnowconeInfo()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [snowconeContract])
+  }, [gaugeProxyContract, account, pools, snowballContract, snowconeContract]);
 
   const getFeeDistributorInfo = async () => {
     try {


### PR DESCRIPTION
# Description
 The major problem I've encountered is that this page does not refresh when you switch wallets. If I connect with a new wallet, my staking information should refresh!

